### PR TITLE
Correctly parse zero-length strings

### DIFF
--- a/protobuf_decoder/protobuf_decoder.py
+++ b/protobuf_decoder/protobuf_decoder.py
@@ -218,8 +218,17 @@ class Parser:
             data_length = self.get_buffered_value()
             self.fetcher.set_data_length(data_length)
 
-            self.state = State.GET_DELIMITED_DATA
-
+            if data_length > 0:
+                self.state = State.GET_DELIMITED_DATA
+            else:
+                self.parsed_data.append(
+                    ParsedResult(
+                        field=self.target_field,
+                        wire_type="string",
+                        data=""
+                    )
+                )
+                self.state = State.FIND_FIELD
             self.buffer.flush()
 
     def get_delimited_data_handler(self, chunk):

--- a/protobuf_decoder/protobuf_decoder.py
+++ b/protobuf_decoder/protobuf_decoder.py
@@ -209,6 +209,17 @@ class Parser:
             self.state = State.FIND_FIELD
             self.buffer.flush()
 
+    def zero_length_delimited_handler(self):
+        self.parsed_data.append(
+            ParsedResult(
+                field=self.target_field,
+                wire_type="string",
+                data=""
+            )
+        )
+        self.state = State.FIND_FIELD
+        self.buffer.flush()
+
     def parse_length_delimited_handler(self, chunk):
         value = self.get_value(chunk)
         if self.has_next(chunk):
@@ -216,19 +227,10 @@ class Parser:
         else:
             self.buffer.append(value)
             data_length = self.get_buffered_value()
+            if data_length == 0:
+                return self.zero_length_delimited_handler()
             self.fetcher.set_data_length(data_length)
-
-            if data_length > 0:
-                self.state = State.GET_DELIMITED_DATA
-            else:
-                self.parsed_data.append(
-                    ParsedResult(
-                        field=self.target_field,
-                        wire_type="string",
-                        data=""
-                    )
-                )
-                self.state = State.FIND_FIELD
+            self.state = State.GET_DELIMITED_DATA
             self.buffer.flush()
 
     def get_delimited_data_handler(self, chunk):

--- a/tests.py
+++ b/tests.py
@@ -219,3 +219,12 @@ def test_parser8():
         ParsedResult(field=1, wire_type="string", data='test'),
         ParsedResult(field=1, wire_type="string", data='test2')
     ])
+
+def test_zero_string():
+    test_target = "0a 00 10 ff ff 03 18 17"
+    parsed_data = Parser().parse(test_target)
+    assert parsed_data == ParsedResults([
+        ParsedResult(field=1, wire_type='string', data=''), 
+        ParsedResult(field=2, wire_type='varint', data=65535), 
+        ParsedResult(field=3, wire_type='varint', data=23)
+    ])


### PR DESCRIPTION
Add a test for zero-length strings
Ensure zero-length strings are parsed correctly
Prior to this, a zero-length string would cause the parser to incorrectly interpret the next byte as a string character

This isn't the cleanest solution, but as far as I can tell it works and doesn't break anything.